### PR TITLE
Enable gRPC calls with a Streaming Response

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       </div>
       <hr/>
       <h4>Response</h4>
+      <div id="response-timing"></div>
       <div id="response-listing">
       </div>
     </div>

--- a/main-menu.js
+++ b/main-menu.js
@@ -42,5 +42,7 @@ const menuTemplate = [
   }
 ]
 
+app.on('ready', ()=> {
 const menu = Menu.buildFromTemplate(menuTemplate)
 Menu.setApplicationMenu(menu)
+}) 

--- a/renderer.js
+++ b/renderer.js
@@ -12,6 +12,7 @@ const dirListing = document.querySelector('#dir-listing')
 const fileName = document.querySelector('#file-name')
 const protoListing = document.querySelector('#proto-listing')
 const requestListing = document.querySelector('#request-listing')
+const responseTiming = document.querySelector('#response-timing')
 const responseListing = document.querySelector('#response-listing')
 const serverHost = document.querySelector('#server-host')
 const serverPort = document.querySelector('#server-port')
@@ -92,13 +93,19 @@ function changeDirectory(path) {
               requestListing.innerHTML = '<pre>'+JSON.stringify(request, undefined, '  ')+'</pre>'
               console.log('Request', request)
               responseListing.innerHTML = '';
+              responseTiming.innerHTML = '<p>Running</p>'
+              var t0 = performance.now();
               method
                 .invokeRpc(request.host, request.port, request.body)
                 .then(response => {
+                  var t1 = performance.now()
+                  responseTiming.innerHTML = `<p>gRPC call - completed in ${(t1-t0).toFixed(3)} milliseconds</p>`
                   responseListing.innerHTML = `<div class="alert alert-success" role="alert"><pre>${JSON.stringify(response, undefined, '  ')}</pre></div>`
                   console.log('Response', response)
                 })
                 .catch(error => {
+                  var t1 = performance.now()
+                  responseTiming.innerHTML = `<p>gRPC call - errored in ${(t1-t0).toFixed(3)} milliseconds</p>`
                   responseListing.innerHTML = `<div class="alert alert-danger" role="alert">${error.toString()}<hr/><pre>${JSON.stringify(error, undefined, '  ')}</pre></div>`
                   console.error('Error', error.toString(), JSON.stringify(error))
                 })


### PR DESCRIPTION
# Streaming Responses
Adding appropriate call semantics for streaming responses.

The approach taken was to buffer responses until the call is complete.  Included some visual indication that the response to the selected call will be a stream of responseType for streaming calls.

# Menus on MacOS
Menus were not loading correctly when running the app on MacOS.  Turns out the calls to set the menu must take place *after* the app Ready event is fired.

# Timing of gRPC calls
I've added a Div to capture how display how long the gRPC call took.  NB This does not include rendering time of the Response